### PR TITLE
wrapping with ensure_packages

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,8 +25,6 @@ class mapserver {
     ],
   }
 
-  package { $packages:
-    ensure => present,
-  }
+  ensure_packages( $packages )
 
 }


### PR DESCRIPTION
Well, you can see from me putting in an issue before putting in the pull request, that I haven't done this before either, I would have just done a pull request with the information.  So here it is again:

I'm installing the mapserver module on a machine with an install of scipy, which also needs gdal-bin and I was getting an error:

"Duplicate declaration: Package[gdal-bin] is already declared in file /tmp/vagrant-puppet/modules-0/python/manifests/init.pp at line 4; cannot redeclare at /tmp/vagrant-puppet/modules-0/mapserver/manifests/init.pp:30 on node precise64.ad.int.nsidc.org"

So I wrapped my python module to use ensure_packages() from the standard library. This didn't work, because it seemed to install the package before arriving at the mapserver.

I'm pretty new to puppet, and don't really know what the solution is, but I forked and "fixed" for me by using the puppet stdlib's ensure_packages() in this module as well. I'll follow up with a pull request and you guys can decide what to do with it. I'm happy to hear/see a better way.

Thanks
Matt
